### PR TITLE
Fix for repository link not working

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/shtian/vscode-svgocd.git"
+        "url": "https://github.com/shtian/vscode-svgocd.git"
     },
     "bugs": {
         "url": "https://github.com/shtian/vscode-svgocd/issues"


### PR DESCRIPTION
Currently, when clicking the repository link from the vscode extensions tab, windows looks for an app that supports a `git +https` protocol. 

https://gfycat.com/greenquarrelsomeafricanbushviper
![greenquarrelsomeafricanbushviper](https://thumbs.gfycat.com/GreenQuarrelsomeAfricanbushviper-size_restricted.gif)

I've just changed it to be in line with official extensions
[Python](https://github.com/microsoft/vscode-python/blob/039e5622c842e2755a24b3c529ba2c1d9e2edf55/package.json#L13) uses this:
```
    "repository": {
        "type": "git",
        "url": "https://github.com/Microsoft/vscode-python"
    },
```

[C/C++ tools](https://github.com/microsoft/vscode-cpptools/blob/bb43c500c208025a6148200ae07593365e938d71/Extension/package.json#L21) uses this:

```
  "repository": {
    "type": "git",
    "url": "https://github.com/Microsoft/vscode-cpptools.git"
  },
```
