### PR TITLE
refactor: read config on command run

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import { commands, ExtensionContext, workspace } from 'vscode';
+import { commands, ExtensionContext } from 'vscode';
 import SVGOCD from './optimizeSVG';
 
 export function activate(context: ExtensionContext): void {
@@ -8,22 +8,6 @@ export function activate(context: ExtensionContext): void {
   const disposable = commands.registerCommand('svgocd.run', () => {
     svgocd.optimizeSVG();
   });
-  context.subscriptions.push(disposable);
 
-  // Refresh svgocd config on relevant change
-  context.subscriptions.push(
-    workspace.onDidChangeConfiguration(e => {
-      if (e.affectsConfiguration('svgocd')) {
-        svgocd.readConfiguration();
-      }
-    }),
-    workspace.onDidSaveTextDocument(doc => {
-      if (/(\.svgo\.ya?ml)/.test(doc.fileName)) {
-        svgocd.readConfiguration();
-      }
-    }),
-    workspace.onDidChangeWorkspaceFolders(() => {
-      svgocd.readConfiguration();
-    })
-  );
+  context.subscriptions.push(disposable);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,4 @@
 import { window, Range } from 'vscode';
-import { statSync } from 'fs';
 
 export const readCurrentFileContent = (): string | null => {
   const editor = window.activeTextEditor;
@@ -51,21 +50,6 @@ export const replaceSelection = (data: string): Thenable<boolean> => {
   return editor.edit(editBuilder => {
     editBuilder.replace(validatedRange, data);
   });
-};
-
-export const getFileSize = (): number | null => {
-  const editor = window.activeTextEditor;
-  if (typeof editor === 'undefined') {
-    return null;
-  }
-
-  let stats;
-  try {
-    stats = statSync(editor.document.fileName);
-  } catch (e) {
-    throw Error('Error reading file: ' + e.message);
-  }
-  return stats.size;
 };
 
 export const getOptimizedPercentage = (fileSizeBefore: number, fileSizeAfter: number): number => {


### PR DESCRIPTION
Config was not read correctly on runs without saving the .svgo.yml file or extension config. Refactored to read on each run for ease, as well as extracting information message generation into it's own method.
Also calculating percentage change based on the input and output to svgo, as this allows percentage calculation when optimizing a selected SVG and not a whole file.