### PR TITLE
Update SVGO to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,14 @@
 ![Workflow](images/howto.gif)
 
 ## ⚙️ Settings
-Settings can either be configured from the extension settings or having a svgo.config.{js,mjs,cjs} file in the workspace directory. A svgo config file will override the extension settings. See the [svgo npm package repository](https://github.com/svg/svgo#configuration) for more information about configuration. 
+Settings can either be configured from the extension settings or having a svgo.config.{js,cjs} file in the workspace directory. A svgo config file will override the extension settings. See the [svgo npm package repository](https://github.com/svg/svgo#configuration) for more information about configuration. 
+
+⚠️ Note that since the extension runs as a CommonJS module in VS Code, only this format is supported by the plugin.
 
 ### Config file
   
 ```js
+/** @type {import('svgo').Config} */
 module.exports = {
   multipass:
   js2svg: {

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Supports all default SVGO plugin settings through extension settings (`svgocd.pl
 | [removeUselessStrokeAndFill](https://github.com/svg/svgo/blob/master/plugins/removeUselessStrokeAndFill.js) | remove useless `stroke` and `fill` attrs |
 | [removeUnusedNS](https://github.com/svg/svgo/blob/master/plugins/removeUnusedNS.js) | remove unused namespaces declaration |
 | [prefixIds](https://github.com/svg/svgo/blob/master/plugins/prefixIds.js) | prefix IDs and classes with the SVG filename or an arbitrary string |
-| [cleanupIDs](https://github.com/svg/svgo/blob/master/plugins/cleanupIDs.js) | remove unused and minify used IDs |
+| [cleanupIds](https://github.com/svg/svgo/blob/master/plugins/cleanupIds.js) | remove unused and minify used IDs |
 | [cleanupNumericValues](https://github.com/svg/svgo/blob/master/plugins/cleanupNumericValues.js) | round numeric values to the fixed precision, remove default `px` units |
 | [cleanupListOfValues](https://github.com/svg/svgo/blob/master/plugins/cleanupListOfValues.js) | round numeric values in attributes that take a list of numbers (like `viewBox` or `enable-background`) |
 | [moveElemsAttrsToGroup](https://github.com/svg/svgo/blob/master/plugins/moveElemsAttrsToGroup.js) | move elements' attributes to their enclosing group |

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Supports all default SVGO plugin settings through extension settings (`svgocd.pl
 | [mergePaths](https://github.com/svg/svgo/blob/master/plugins/mergePaths.js) | merge multiple Paths into one |
 | [convertShapeToPath](https://github.com/svg/svgo/blob/master/plugins/convertShapeToPath.js) | convert some basic shapes to `<path>` |
 | [convertEllipseToCircle](https://github.com/svg/svgo/blob/master/plugins/convertEllipseToCircle.js) | convert non-eccentric `<ellipse>` to `<circle>` |
-| [sortAttrs](https://github.com/svg/svgo/blob/master/plugins/sortAttrs.js) | sort element attributes for epic readability (disabled by default) |
+| [sortAttrs](https://github.com/svg/svgo/blob/master/plugins/sortAttrs.js) | sort element attributes for epic readability |
 | [sortDefsChildren](https://github.com/svg/svgo/blob/master/plugins/sortDefsChildren.js) | sort children of `<defs>` in order to improve compression |
 | [removeDimensions](https://github.com/svg/svgo/blob/master/plugins/removeDimensions.js) | remove `width`/`height` and add `viewBox` if it's missing (opposite to removeViewBox, disable it first) (disabled by default) |
 | [removeAttrs](https://github.com/svg/svgo/blob/master/plugins/removeAttrs.js) | remove attributes by pattern (disabled by default) |

--- a/example/svgo.config.js
+++ b/example/svgo.config.js
@@ -1,4 +1,4 @@
-/** @type {import('svgo').OptimizeOptions} */
+/** @type {import('svgo').Config} */
 module.exports = {
   multipass: true, // boolean. false by default
   js2svg: {

--- a/example/svgs/target.svg
+++ b/example/svgs/target.svg
@@ -1,6 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.4.0, SVG Export Plug-In . SVG Version: 4.00 Build 20)  -->
 <!-- Some comment -->
 <svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M14 22C18.4183 22 22 18.4183 22 14C22 9.58172 18.4183 6 14 6C9.58172 6 6 9.58172 6 14C6 18.4183 9.58172 22 14 22ZM14 24C19.5228 24 24 19.5228 24 14C24 8.47715 19.5228 4 14 4C8.47715 4 4 8.47715 4 14C4 19.5228 8.47715 24 14 24Z" fill="black"/>
+<path fill-rule="evenodd" random-attribute-should-be-removed="please" clip-rule="evenodd" d="M14 22C18.4183 22 22 18.4183 22 14C22 9.58172 18.4183 6 14 6C9.58172 6 6 9.58172 6 14C6 18.4183 9.58172 22 14 22ZM14 24C19.5228 24 24 19.5228 24 14C24 8.47715 19.5228 4 14 4C8.47715 4 4 8.47715 4 14C4 19.5228 8.47715 24 14 24Z" fill="black"/>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M15 0V5H13L13 0H15Z" fill="black"/>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M15 23V28H13L13 23H15Z" fill="black"/>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M28 15L23 15V13L28 13V15Z" fill="black"/>

--- a/package.json
+++ b/package.json
@@ -346,7 +346,7 @@
                             "boolean",
                             "object"
                         ],
-                        "default": false,
+                        "default": true,
                         "description": "sort element attributes for epic readability (disabled by default)"
                     },
                     "svgocd.plugins.sortDefsChildren": {

--- a/package.json
+++ b/package.json
@@ -472,7 +472,6 @@
     "devDependencies": {
         "@types/glob": "^7.2.0",
         "@types/node": "^13.1.0",
-        "@types/svgo": "^2.6.4",
         "@types/vscode": "^1.72.0",
         "@typescript-eslint/eslint-plugin": "^5.40.1",
         "@typescript-eslint/parser": "^5.40.1",
@@ -485,6 +484,6 @@
     },
     "dependencies": {
         "deepmerge": "^4.2.2",
-        "svgo": "^2.8.0"
+        "svgo": "^3.0.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -261,7 +261,7 @@
                         "default": true,
                         "description": "prefix IDs and classes with the SVG filename or an arbitrary string"
                     },
-                    "svgocd.plugins.cleanupIDs": {
+                    "svgocd.plugins.cleanupIds": {
                         "type": [
                             "boolean",
                             "object"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,7 +3,6 @@ lockfileVersion: 5.4
 specifiers:
   '@types/glob': ^7.2.0
   '@types/node': ^13.1.0
-  '@types/svgo': ^2.6.4
   '@types/vscode': ^1.72.0
   '@typescript-eslint/eslint-plugin': ^5.40.1
   '@typescript-eslint/parser': ^5.40.1
@@ -13,17 +12,16 @@ specifiers:
   eslint-config-prettier: ^8.5.0
   eslint-plugin-prettier: ^4.2.1
   prettier: ^2.7.1
-  svgo: ^2.8.0
+  svgo: ^3.0.0
   typescript: ^4.8.4
 
 dependencies:
   deepmerge: 4.2.2
-  svgo: 2.8.0
+  svgo: 3.0.0
 
 devDependencies:
   '@types/glob': 7.2.0
   '@types/node': 13.13.52
-  '@types/svgo': 2.6.4
   '@types/vscode': 1.72.0
   '@typescript-eslint/eslint-plugin': 5.40.1_ukgdydjtebaxmxfqp5v5ulh64y
   '@typescript-eslint/parser': 5.40.1_z4bbprzjrhnsfa24uvmcbu7f5q
@@ -138,12 +136,6 @@ packages:
 
   /@types/semver/7.3.12:
     resolution: {integrity: sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==}
-    dev: true
-
-  /@types/svgo/2.6.4:
-    resolution: {integrity: sha512-l4cmyPEckf8moNYHdJ+4wkHvFxjyW6ulm9l4YGaOxeyBWPhBOT0gvni1InpFPdzx1dKf/2s62qGITwxNWnPQng==}
-    dependencies:
-      '@types/node': 13.13.52
     dev: true
 
   /@types/vscode/1.72.0:
@@ -386,22 +378,22 @@ packages:
       which: 2.0.2
     dev: true
 
-  /css-select/4.3.0:
-    resolution: {integrity: sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==}
+  /css-select/5.1.0:
+    resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
     dependencies:
       boolbase: 1.0.0
       css-what: 6.1.0
-      domhandler: 4.3.1
-      domutils: 2.8.0
+      domhandler: 5.0.3
+      domutils: 3.0.1
       nth-check: 2.1.1
     dev: false
 
-  /css-tree/1.1.3:
-    resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
-    engines: {node: '>=8.0.0'}
+  /css-tree/2.2.1:
+    resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
     dependencies:
-      mdn-data: 2.0.14
-      source-map: 0.6.1
+      mdn-data: 2.0.28
+      source-map-js: 1.0.2
     dev: false
 
   /css-what/6.1.0:
@@ -409,11 +401,11 @@ packages:
     engines: {node: '>= 6'}
     dev: false
 
-  /csso/4.2.0:
-    resolution: {integrity: sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==}
-    engines: {node: '>=8.0.0'}
+  /csso/5.0.5:
+    resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
     dependencies:
-      css-tree: 1.1.3
+      css-tree: 2.2.1
     dev: false
 
   /debug/4.3.4:
@@ -451,35 +443,36 @@ packages:
       esutils: 2.0.3
     dev: true
 
-  /dom-serializer/1.4.1:
-    resolution: {integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==}
+  /dom-serializer/2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
     dependencies:
       domelementtype: 2.3.0
-      domhandler: 4.3.1
-      entities: 2.2.0
+      domhandler: 5.0.3
+      entities: 4.4.0
     dev: false
 
   /domelementtype/2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
     dev: false
 
-  /domhandler/4.3.1:
-    resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
+  /domhandler/5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
     dependencies:
       domelementtype: 2.3.0
     dev: false
 
-  /domutils/2.8.0:
-    resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
+  /domutils/3.0.1:
+    resolution: {integrity: sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==}
     dependencies:
-      dom-serializer: 1.4.1
+      dom-serializer: 2.0.0
       domelementtype: 2.3.0
-      domhandler: 4.3.1
+      domhandler: 5.0.3
     dev: false
 
-  /entities/2.2.0:
-    resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
+  /entities/4.4.0:
+    resolution: {integrity: sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==}
+    engines: {node: '>=0.12'}
     dev: false
 
   /esbuild-android-64/0.15.12:
@@ -1063,8 +1056,8 @@ packages:
       yallist: 4.0.0
     dev: true
 
-  /mdn-data/2.0.14:
-    resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
+  /mdn-data/2.0.28:
+    resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==}
     dev: false
 
   /merge2/1.4.1:
@@ -1248,14 +1241,9 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /source-map/0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+  /source-map-js/1.0.2:
+    resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
-    dev: false
-
-  /stable/0.1.8:
-    resolution: {integrity: sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==}
-    deprecated: 'Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility'
     dev: false
 
   /strip-ansi/6.0.1:
@@ -1277,18 +1265,17 @@ packages:
       has-flag: 4.0.0
     dev: true
 
-  /svgo/2.8.0:
-    resolution: {integrity: sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==}
-    engines: {node: '>=10.13.0'}
+  /svgo/3.0.0:
+    resolution: {integrity: sha512-mSqPn6RDeNqJvCeqHERlfWJjd4crP/2PgFelil9WpTwC4D3okAUopPsH3lnEyl7ONXfDVyISOihDjO0uK8YVAA==}
+    engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:
       '@trysound/sax': 0.2.0
       commander: 7.2.0
-      css-select: 4.3.0
-      css-tree: 1.1.3
-      csso: 4.2.0
+      css-select: 5.1.0
+      css-tree: 2.2.1
+      csso: 5.0.5
       picocolors: 1.0.0
-      stable: 0.1.8
     dev: false
 
   /text-table/0.2.0:

--- a/src/optimizeSVG.ts
+++ b/src/optimizeSVG.ts
@@ -1,4 +1,4 @@
-import { optimize, OptimizedError, OptimizedSvg } from 'svgo';
+import { optimize } from 'svgo';
 import { window } from 'vscode';
 import { getSVGOConfig } from './configuration';
 import {
@@ -8,10 +8,6 @@ import {
   replaceSelection,
   getOptimizedPercentage,
 } from './utils';
-
-function isOptimizedError(svgoResult: OptimizedSvg | OptimizedError): svgoResult is OptimizedError {
-  return typeof svgoResult.error !== 'undefined';
-}
 
 export default class SVGOCD {
   public async optimizeSVG(): Promise<boolean> {
@@ -30,8 +26,6 @@ export default class SVGOCD {
 
     try {
       const optimizedSVGResult = optimize(svgToOptimize, svgoConfig);
-
-      if (isOptimizedError(optimizedSVGResult)) throw new Error(optimizedSVGResult.error);
 
       if (selection) {
         await replaceSelection(optimizedSVGResult.data);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
 		"sourceMap": true,
 		"rootDir": "src",
 		"strict": true,
-		"allowJs": true
+		"allowJs": true,
+		"skipLibCheck": true
 	},
 	"exclude": [
 		"node_modules",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,10 +8,16 @@
 		],
 		"sourceMap": true,
 		"rootDir": "src",
-		"strict": true
+		"strict": true,
+		"allowJs": true
 	},
 	"exclude": [
 		"node_modules",
-		".vscode-test"
+		".vscode-test",
+		"examples",
+		"out"
+	],
+	"include": [
+		"src"
 	]
 }


### PR DESCRIPTION
Updating SVGO dependency to v3.0.0 https://github.com/svg/svgo/releases/tag/v3.0.0

- [x] Handle `optimize()` no longer returns errors as an objects and throws them instead
- [x] `sortAttrs` now enabled by default, reflect this in the extension settings
- [x] Rename the default plugin `cleanupIDs` to `cleanupIds`
- [x] Explicitly fail .mjs config imports and update README
- [x] Remove @types/svgo since these are now directly exported by the svgo package
- [x] Update the types exported by svgo package